### PR TITLE
Conversation 7 favorite itineraries feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Travel Itinerary Planner
+﻿# Travel Itinerary Planner
 
 A command-line application for creating and managing travel itineraries.
 
@@ -360,6 +360,111 @@ All exported files are saved in the `exports/` directory with filenames based on
 - Itineraries: `exports/itinerary_<id>.[md|csv]`
 - Packing Lists: `exports/packing_<id>.[md|csv]`
 - Expenses: `exports/expenses_<id>.[md|csv]`
+
+
+## Managing Favorites
+
+You can mark itineraries as favorites for easy access and reference.
+
+### Marking Favorites
+
+To mark an itinerary as a favorite:
+```
+./travel_planner itinerary favorite <id>
+```
+
+or use the shortcut:
+```
+./travel_planner fav <id>
+```
+
+Example:
+```
+./travel_planner fav abc123
+```
+
+Output:
+```
+Itinerary 'Summer in Paris' marked as favorite.
+```
+
+### Removing Favorite Status
+
+To remove the favorite status:
+```
+./travel_planner itinerary unfavorite <id>
+```
+
+or use the shortcut:
+```
+./travel_planner unfav <id>
+```
+
+Example:
+```
+./travel_planner unfav abc123
+```
+
+Output:
+```
+Favorite status removed from itinerary 'Summer in Paris'.
+```
+
+### Viewing Favorite Itineraries
+
+To view only your favorite itineraries:
+```
+./travel_planner itinerary favorites
+```
+
+Example output:
+```
+ID      Name                  Favorite
+abc123  Summer in Paris       ★
+def456  Tokyo Adventure       ★
+
+2 itineraries found.
+```
+
+### Visual Indication
+
+When listing all itineraries, favorite items are marked with a star (★) symbol:
+```
+./travel_planner list
+```
+
+Example output:
+```
+ID      Name                  Favorite
+abc123  Summer in Paris       ★
+def456  Tokyo Adventure       ★
+ghi789  London Weekend
+
+3 itineraries found.
+```
+
+## Searching Itineraries
+
+You can search through your itineraries using keywords that match against the name or description:
+```
+./travel_planner itinerary search <keyword>
+```
+
+Example:
+```
+./travel_planner itinerary search beach
+```
+
+Output:
+```
+ID      Name                  Favorite
+jkl012  Beach Getaway         ★
+mno345  Miami Spring Break
+
+2 itineraries found matching 'beach'.
+```
+
+The search is case-insensitive and will match partial words in both the name and description fields.
 
 
 ## License

--- a/include/Itinerary.h
+++ b/include/Itinerary.h
@@ -13,6 +13,7 @@ namespace travel_planner {
         std::string end_date;
         std::string description;
         std::vector<std::string> tags;  // New field for tags
+        bool is_favorite = false;
 
         Itinerary() = default;
 
@@ -21,7 +22,7 @@ namespace travel_planner {
             const std::string& description,
             const std::vector<std::string>& tags = {})  // Updated constructor
             : id(id), name(name), start_date(start_date),
-            end_date(end_date), description(description), tags(tags) {
+            end_date(end_date), description(description), tags(tags), is_favorite(is_favorite) {
         }
     };
 
@@ -33,7 +34,8 @@ namespace travel_planner {
             {"start_date", itinerary.start_date},
             {"end_date", itinerary.end_date},
             {"description", itinerary.description},
-            {"tags", itinerary.tags}  // Added tags serialization
+            {"tags", itinerary.tags},  // Added tags serialization
+            { "is_favorite", itinerary.is_favorite }
         };
     }
 
@@ -45,6 +47,14 @@ namespace travel_planner {
         j.at("end_date").get_to(itinerary.end_date);
         j.at("description").get_to(itinerary.description);
         j.at("tags").get_to(itinerary.tags);  // Added tags deserialization
+
+        // Handle backward compatibility
+        if (j.contains("is_favorite")) {
+            j.at("is_favorite").get_to(itinerary.is_favorite);
+        }
+        else {
+            itinerary.is_favorite = false; // Default value if not present
+        }
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1273,4 +1273,50 @@ void unfavoriteItinerary(const std::string& id) {
     storageManager.saveAll(itineraries);
     std::cout << "Favorite status removed from itinerary '" << it->name << "'." << std::endl;
 }
+void listFavoriteItineraries() {
+    travel_planner::StorageManager storageManager("data/itineraries.json");
+    std::vector<travel_planner::Itinerary> allItineraries = storageManager.loadAll();
+
+    // Filter for favorite itineraries only
+    std::vector<travel_planner::Itinerary> favoriteItineraries;
+    std::copy_if(allItineraries.begin(), allItineraries.end(),
+        std::back_inserter(favoriteItineraries),
+        [](const travel_planner::Itinerary& itin) { return itin.is_favorite; });
+
+    if (favoriteItineraries.empty()) {
+        std::cout << "No favorite itineraries found." << std::endl;
+        return;
+    }
+
+    // Find the longest ID and name for formatting
+    size_t maxIdLength = 2; // "ID" header length
+    size_t maxNameLength = 4; // "Name" header length
+
+    for (const auto& itinerary : favoriteItineraries) {
+        maxIdLength = std::max(maxIdLength, itinerary.id.length());
+        maxNameLength = std::max(maxNameLength, itinerary.name.length());
+    }
+
+    // Add some padding
+    maxIdLength += 2;
+    maxNameLength += 2;
+
+    // Print headers
+    std::cout << std::left << std::setw(maxIdLength) << "ID"
+        << std::setw(maxNameLength) << "Name" << std::endl;
+
+    // Print separator line
+    std::cout << std::string(maxIdLength + maxNameLength, '-') << std::endl;
+
+    // Print itineraries
+    for (const auto& itinerary : favoriteItineraries) {
+        std::cout << std::left << std::setw(maxIdLength) << itinerary.id
+            << std::setw(maxNameLength) << itinerary.name << std::endl;
+    }
+
+    // Print count
+    std::cout << std::endl << favoriteItineraries.size()
+        << " favorite " << (favoriteItineraries.size() == 1 ? "itinerary" : "itineraries")
+        << " found." << std::endl;
+}
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1247,4 +1247,30 @@ void favoriteItinerary(const std::string& id) {
     storageManager.saveAll(itineraries);
     std::cout << "Itinerary '" << it->name << "' marked as favorite." << std::endl;
 }
+void unfavoriteItinerary(const std::string& id) {
+    if (id.empty()) {
+        std::cerr << "Error: Itinerary ID is required." << std::endl;
+        return;
+    }
+
+    travel_planner::StorageManager storageManager("data/itineraries.json");
+    std::vector<travel_planner::Itinerary> itineraries = storageManager.loadAll();
+
+    auto it = std::find_if(itineraries.begin(), itineraries.end(),
+        [&id](const travel_planner::Itinerary& itinerary) {
+            return itinerary.id == id;
+        });
+
+    if (it == itineraries.end()) {
+        std::cerr << "Error: No itinerary found with ID: " << id << std::endl;
+        return;
+    }
+
+    // Remove the favorite status
+    it->is_favorite = false;
+
+    // Save the updated list
+    storageManager.saveAll(itineraries);
+    std::cout << "Favorite status removed from itinerary '" << it->name << "'." << std::endl;
+}
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1221,4 +1221,30 @@ void exportExpense(const std::vector<std::string>& args) {
     else {
         std::cerr << "Error: Failed to export expenses. Please check if the itinerary exists." << std::endl;
     }
+void favoriteItinerary(const std::string& id) {
+    if (id.empty()) {
+        std::cerr << "Error: Itinerary ID is required." << std::endl;
+        return;
+    }
+
+    travel_planner::StorageManager storageManager("data/itineraries.json");
+    std::vector<travel_planner::Itinerary> itineraries = storageManager.loadAll();
+
+    auto it = std::find_if(itineraries.begin(), itineraries.end(),
+        [&id](const travel_planner::Itinerary& itinerary) {
+            return itinerary.id == id;
+        });
+
+    if (it == itineraries.end()) {
+        std::cerr << "Error: No itinerary found with ID: " << id << std::endl;
+        return;
+    }
+
+    // Set the itinerary as favorite
+    it->is_favorite = true;
+
+    // Save the updated list
+    storageManager.saveAll(itineraries);
+    std::cout << "Itinerary '" << it->name << "' marked as favorite." << std::endl;
+}
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1319,4 +1319,73 @@ void listFavoriteItineraries() {
         << " favorite " << (favoriteItineraries.size() == 1 ? "itinerary" : "itineraries")
         << " found." << std::endl;
 }
+std::string toLower(const std::string& str) {
+    std::string result = str;
+    std::transform(result.begin(), result.end(), result.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+    return result;
+}
+
+// Helper function for case-insensitive substring check
+bool caseInsensitiveContains(const std::string& str, const std::string& substr) {
+    std::string lowerStr = toLower(str);
+    std::string lowerSubstr = toLower(substr);
+    return lowerStr.find(lowerSubstr) != std::string::npos;
+}
+
+// Function to search itineraries by keyword
+void searchItinerariesByKeyword(const std::string& keyword) {
+    if (keyword.empty()) {
+        std::cerr << "Error: Search keyword is required." << std::endl;
+        return;
+    }
+
+    travel_planner::StorageManager storageManager("data/itineraries.json");
+    std::vector<travel_planner::Itinerary> allItineraries = storageManager.loadAll();
+
+    // Filter for matching itineraries
+    std::vector<travel_planner::Itinerary> matchingItineraries;
+
+    for (const auto& itinerary : allItineraries) {
+        if (caseInsensitiveContains(itinerary.name, keyword) ||
+            caseInsensitiveContains(itinerary.description, keyword)) {
+            matchingItineraries.push_back(itinerary);
+        }
+    }
+
+    if (matchingItineraries.empty()) {
+        std::cout << "No itineraries found matching '" << keyword << "'." << std::endl;
+        return;
+    }
+
+    // Find the longest ID and name for formatting
+    size_t maxIdLength = 2; // "ID" header length
+    size_t maxNameLength = 4; // "Name" header length
+
+    for (const auto& itinerary : matchingItineraries) {
+        maxIdLength = std::max(maxIdLength, itinerary.id.length());
+        maxNameLength = std::max(maxNameLength, itinerary.name.length());
+    }
+
+    // Add some padding
+    maxIdLength += 2;
+    maxNameLength += 2;
+
+    // Print headers
+    std::cout << std::left << std::setw(maxIdLength) << "ID"
+        << std::setw(maxNameLength) << "Name" << std::endl;
+
+    // Print separator line
+    std::cout << std::string(maxIdLength + maxNameLength, '-') << std::endl;
+
+    // Print matching itineraries
+    for (const auto& itinerary : matchingItineraries) {
+        std::cout << std::left << std::setw(maxIdLength) << itinerary.id
+            << std::setw(maxNameLength) << itinerary.name << std::endl;
+    }
+
+    // Print count
+    std::cout << std::endl << matchingItineraries.size()
+        << " " << (matchingItineraries.size() == 1 ? "itinerary" : "itineraries")
+        << " found matching '" << keyword << "'." << std::endl;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -407,9 +407,6 @@ void addItinerary() {
 }
 
 void listItineraries() {
-    std::cout << "Loading itineraries...\n";
-
-    // Create storage manager with default path
 	travel_planner::StorageManager storageManager("data/itineraries.json");
 
     // Load all itineraries
@@ -430,21 +427,34 @@ void listItineraries() {
         nameWidth = std::max(nameWidth, itinerary.name.length() + 2);
     }
 
-    // Print table header
-    std::cout << std::string(idWidth + nameWidth + 3, '-') << '\n';
-    std::cout << "| " << std::left << std::setw(idWidth) << "ID"
-        << "| " << std::setw(nameWidth) << "Name" << "|\n";
-    std::cout << std::string(idWidth + nameWidth + 3, '-') << '\n';
+    // Add some padding
+    maxIdLength += 2;
+    maxNameLength += 2;
+
+    // Length for favorite column
+    const size_t favColumnWidth = 10;
+
+    // Print headers
+    std::cout << std::left
+        << std::setw(maxIdLength) << "ID"
+        << std::setw(maxNameLength) << "Name"
+        << std::setw(favColumnWidth) << "Favorite" << std::endl;
+
+    // Print separator line
+    std::cout << std::string(maxIdLength + maxNameLength + favColumnWidth, '-') << std::endl;
 
     // Print each itinerary
     for (const auto& itinerary : itineraries) {
-        std::cout << "| " << std::left << std::setw(idWidth) << itinerary.id
-            << "| " << std::setw(nameWidth) << itinerary.name << "|\n";
+        std::cout << std::left
+            << std::setw(maxIdLength) << itinerary.id
+            << std::setw(maxNameLength) << itinerary.name
+            << std::setw(favColumnWidth) << (itinerary.is_favorite ? "*" : "") << std::endl;
     }
 
-    // Print table footer
-    std::cout << std::string(idWidth + nameWidth + 3, '-') << '\n';
-    std::cout << itineraries.size() << " itinerary/ies found.\n";
+    // Print count
+    std::cout << std::endl << itineraries.size()
+        << " " << (itineraries.size() == 1 ? "itinerary" : "itineraries")
+        << " found." << std::endl;
 }
 
 void viewItinerary(const std::string& id) {


### PR DESCRIPTION
The workflow added support for marking itineraries as favorites with is_favorite field integration, CLI commands to favorite/unfavorite itineraries, list only favorites, and perform keyword-based search. Shortcuts like fav and unfav were introduced, visual indicators (*) were added to listings, and all new features were documented in the README for clarity and usability.